### PR TITLE
Functions to easily highlight a whole line and clear said highlight.

### DIFF
--- a/autoload/highlighter.vim
+++ b/autoload/highlighter.vim
@@ -460,6 +460,22 @@ function s:SetPosHighlight(block, num)
   call s:UpdateJump(s:GetJump()[0], l:group)
 endfunction
 
+
+function highlighter#MyHiLine(line, number)
+  if !exists("s:Colors") && !s:Load()
+    return
+  endif
+  let l:fullline = {'mode': 'v', 'rect': [a:line, 1, a:line, 10000]}
+  call s:SetPosHighlight(l:fullline, a:number)
+endfunction
+
+function highlighter#MyDelHiLine(line)
+  call s:DeletePosHighlightAt([0,a:line,1,0])
+endfunction
+
+
+
+
 function s:DeletePosHighlight(rect)
   if s:PI
     let l:props = prop_list(a:rect[0], {'end_lnum':a:rect[2]})


### PR DESCRIPTION
Dear azabiong,

I needed to find a way to highlight multiple lines in vim with different colors for an inspection tool.
This tool is able to show the execution stack of a program being debugged (e.g., C or Python).
It looks as follows:
![easytracker](https://github.com/user-attachments/assets/82da01dd-b9a9-479f-8612-ac37990a88cc)

To do this, I modified your excellent plugin `vim-highlighter`, but my knowledge of VimL is limited, I just looked at what the other functions where  doing and tried to call `s:SetPosHighlight` and `s:DeletePosHighlightAt`.

Now there are two new functions available, but maybe it would be cleaner to extent `highlighter#command` with new arguments.

Thank you for your time and for creating `vim-highlighter`.
